### PR TITLE
Tighten Jekyll-API surface and fix Render-cache staleness bug

### DIFF
--- a/lib/cheesy-gallery/base_image_file.rb
+++ b/lib/cheesy-gallery/base_image_file.rb
@@ -23,41 +23,47 @@ class CheesyGallery::BaseImageFile < Jekyll::StaticFile
     img.write(path) {}
   end
 
-  # Inject cache here to override default delete-before-copy behaviour
-  # See jekyll:lib/jekyll/static_file.rb for source
+  # Skip the render when our content-aware Render-cache key says we've
+  # already produced this exact (dest, source-mtime) pair and the
+  # destination is still on disk. Otherwise defer to Jekyll's StaticFile
+  # write, which handles the modified? check, mkdir_p, rm of an existing
+  # dest, and the call to our overridden copy_file below.
   def write(dest)
     dest_path = destination(dest)
-    return false if File.exist?(dest_path) && !modified?
+    if File.exist?(dest_path) && @@render_cache.key?(render_cache_key(dest_path))
+      self.class.mtimes[path] = mtime
+      return false
+    end
 
-    self.class.mtimes[path] = mtime
-
-    return if @@render_cache.key?("#{dest_path}-rendered") && File.exist?(dest_path)
-
-    FileUtils.mkdir_p(File.dirname(dest_path))
-    FileUtils.rm(dest_path) if File.exist?(dest_path)
-    copy_file(dest_path)
-
-    @@render_cache["#{dest_path}-rendered"] = true
-
-    true
+    super
   end
 
   private
 
-  # instead of copying, allow rmagick processing
-  # this is only called if the mtime doesn't match
+  # Render-cache key is dest_path plus source mtime so that an in-place
+  # source edit (or a re-pointed git-annex symlink) invalidates the
+  # cached marker naturally. Stale entries under old keys linger on
+  # disk until `jekyll clean`; cosmetic.
+  def render_cache_key(dest_path)
+    "#{dest_path}##{mtime.to_i}-rendered"
+  end
+
+  # Replace Jekyll's StaticFile#copy_file (FileUtils.cp) with RMagick
+  # rendering. Super's write has already mkdir_p'd the parent and
+  # rm'd any existing dest_path before getting here.
   def copy_file(dest_path)
     source = Magick::ImageList.new(path)
     begin
       Jekyll.logger.debug 'Rendering:', dest_path
       process_and_write(source, dest_path)
     ensure
-      # clean up cache
       source.destroy!
     end
 
-    unless File.symlink?(dest_path) # rubocop:disable Style/GuardClause
-      File.utime(self.class.mtimes[@source_file.path], self.class.mtimes[@source_file.path], dest_path)
+    unless File.symlink?(dest_path)
+      File.utime(self.class.mtimes[path], self.class.mtimes[path], dest_path)
     end
+
+    @@render_cache[render_cache_key(dest_path)] = true
   end
 end

--- a/lib/cheesy-gallery/gallery_index.rb
+++ b/lib/cheesy-gallery/gallery_index.rb
@@ -4,8 +4,10 @@
 class CheesyGallery::GalleryIndex < Jekyll::Document
   DEFAULT_CONTENT = "This page intentionally left blank.\n"
 
-  # skip reading content, as there is by definition no backing file for this
-  def read_content(_opts = nil)
+  # No backing file exists — calling super would try File.read(path) and
+  # abort the build. Mirror Jekyll::Document#read minus the file I/O.
+  def read(_opts = {})
+    merge_defaults
     self.content = DEFAULT_CONTENT
   end
 end

--- a/lib/cheesy-gallery/generator.rb
+++ b/lib/cheesy-gallery/generator.rb
@@ -8,6 +8,9 @@ require 'cheesy-gallery/image_thumb'
 
 # The generator modifies the `site` data structure to contain all data necessary by the layouts and tags to render the galleries
 class CheesyGallery::Generator < Jekyll::Generator
+  safe true
+  priority :low
+
   def generate(site)
     @site = site
     (site.collections.values.find_all { |c| c.metadata['cheesy-gallery'] } || [site.collections['galleries']]).compact.each do |collection|

--- a/spec/cheesy/cache_spec.rb
+++ b/spec/cheesy/cache_spec.rb
@@ -230,11 +230,7 @@ RSpec.describe 'cheesy-gallery cache behaviour' do
   # --- §3.3 scenario 4: edited source, dest_path unchanged ------------
 
   describe 'scenario 4: source edited in place, dest_path unchanged' do
-    it 'documents the Layer-B-shadows-Layer-A bug: dest is stale (PENDING)' do
-      pending 'docs/cache-analysis.md §3.3 #4: Render cache keys only on ' \
-              'dest_path so an in-place source edit is silently skipped. ' \
-              'Fix per §7.1.'
-
+    it 're-renders because the Render-cache key includes the source mtime' do
       build!
       target_source = File.join(source_dir, '_gallery', CHEESY_CACHE_FIXTURE_JPGS.first)
       target_dest   = File.join(dest_dir,   'gallery',  CHEESY_CACHE_FIXTURE_JPGS.first)
@@ -248,32 +244,8 @@ RSpec.describe 'cheesy-gallery cache behaviour' do
       reset_counters!
       build!
 
-      # Desired behaviour after fix: the cache notices the source
-      # changed and re-renders. Today it doesn't, and these
-      # expectations fail; the `pending` marker keeps the test green.
       expect(@decode_count).to be > 0
       expect(File.mtime(target_dest)).not_to eq(original_dest_mtime)
-    end
-
-    it 'still records the bug as a regression check' do
-      # Inverse of the pending test above: assert the buggy behaviour
-      # we currently ship so that a fix shows up as a deliberate
-      # change to the suite, not a surprise.
-      build!
-      target_source = File.join(source_dir, '_gallery', CHEESY_CACHE_FIXTURE_JPGS.first)
-      target_dest   = File.join(dest_dir,   'gallery',  CHEESY_CACHE_FIXTURE_JPGS.first)
-      dest_mtime_before = File.mtime(target_dest)
-
-      future = Time.now + 60
-      File.utime(future, future, target_source)
-
-      simulate_cold_process!
-      reset_counters!
-      build!
-
-      expect(@decode_count).to eq(0),
-                               'Layer B hit despite source change — known bug'
-      expect(File.mtime(target_dest)).to eq(dest_mtime_before)
     end
   end
 


### PR DESCRIPTION
## Summary

Implements the "stay the course, but tighten" branch of `docs/jekyll-api-review.md` §3.1. Three small, independent commits against Jekyll 4.4.1.

- **`8a1602a` Generator: `safe true` + `priority :low`.** No-op behavioural declarations — `safe true` makes us whitelistable under `--safe`; `priority :low` runs us after default-priority generators so we see anything they inject into `collection.files`. Trade-off: synthetic `GalleryIndex` docs are invisible to earlier generators; acceptable for current deployments.

- **`e118c10` Fix Layer-B-shadows-Layer-A staleness in the Render cache.** The Render-cache short-circuit in `BaseImageFile#write` keyed only on `dest_path`, so an in-place source edit (or a re-pointed git-annex symlink) was silently skipped on subsequent builds — `docs/cache-analysis.md` §3.3 scenario 4, §7.1. Fix: include the source mtime in the cache key (`"#{dest_path}##{mtime.to_i}-rendered"`) so source edits produce a new key, miss, and re-render. Cold builds with unchanged sources still hit because the key is reproducible. Also drops the bespoke `mkdir_p`+`rm` dance — Jekyll's `StaticFile#write` already does both before calling `copy_file`, so the override defers to `super` once the cache lets us through; the RMagick rendering moves cleanly into the `copy_file` override. `spec/cheesy/cache_spec.rb` scenario 4: the PENDING test that asserted the desired post-fix behaviour now passes; the sibling test that pinned the buggy behaviour as a regression check is removed.

- **`d5133a6` Override `Document#read` instead of the private `read_content`.** `read_content` is private in Jekyll 4.x. `GalleryIndex` stands in for gallery directories without an `index.html`, so there is no backing file — calling `super` from a `read` override would try `File.read(path)`, hit `ENOENT`, and the `handle_read_error` rescue aborts the build in 4.4.1. Override `read` directly without calling `super`, mirroring Jekyll's own sequence minus the file I/O. `read_post_data` is intentionally skipped (it can touch `File.mtime(path)`).

## Not changing (with justification)

- **Cache invalidation on `_config.yml` change.** Jekyll's `Site#process` already calls `Jekyll::Cache.clear_if_config_changed`, which `rm -rf`s the whole cache dir, taking both our named caches with it. Confirmed by `cache_spec.rb` "§4: invalidation behaviour". No plugin-side hook needed.
- **`--disable-disk-cache`.** `Jekyll::Cache` already short-circuits disk I/O via the class flag; our caches inherit it for free.
- **Capping the Geometry cache (`cache-analysis.md` §7.4)** and **sharing `mtimes` between subclasses (§7.5)**. Tighten-shaped but outside this stage; deferred.

## Test plan

- [x] `bundle exec rake spec` — 23 examples, 0 failures (scenario 4 ex-pending test passes).
- [x] `bundle exec rake rubocop` — 14 files inspected, no offenses.
- [x] `spec/fixtures/test_site` `jekyll build` produces `_site/gallery_one/index.html`, `_site/gallery_two/index.html` (synthetic `GalleryIndex` regression path — no on-disk file), `_site/gallery_two/third/index.html`, and all `*.jpg`/`*_thumb.jpg`/`*_index.jpg` variants. No `FATAL` lines.
- [x] Manual scenario-4 check: `jekyll build`, `touch _gallery_one/Halloween13-39.jpg`, `jekyll build` again — dest mtime advanced from `1778269121` to `1778573739`, confirming the staleness fix.

https://claude.ai/code/session_012qFfQbwnNFX3jcanNp9xDk