### PR TITLE
Close out todos and prep 1.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,91 @@
 # 1.2.0
 
-* **Breaking install change:** image processing switched from RMagick
-  to libvips (via [ruby-vips](https://github.com/libvips/ruby-vips)).
-  Install `libvips` (e.g. `apt install libvips42 libvips-dev` or
-  `brew install vips`) instead of ImageMagick / libmagickwand-dev. See
+## User-visible changes
+
+### Breaking
+
+* **Install:** image processing switched from RMagick to libvips (via
+  [ruby-vips](https://github.com/libvips/ruby-vips)). Install `libvips`
+  (e.g. `apt install libvips42 libvips-dev` or `brew install vips`)
+  instead of ImageMagick / libmagickwand-dev. See
   `docs/libvips-bench.md` for the perf comparison that motivated the
   swap.
-* **Behaviour change:** EXIF Orientation is now honoured. Sources that
-  previously rendered sideways (Orientation 5–8) will now render
-  upright. Output JPEGs no longer carry the orientation tag.
-* **Behaviour change:** every rendered JPEG (full-size + thumbs) now
+* **Ruby:** `required_ruby_version` raised from `>= 2.6.0` to `>= 3.2`.
+  CI now runs on 3.2 / 3.3 / 3.4 / 4.0.
+* **Jekyll:** gem constraint tightened from `~> 4.0` to `~> 4.4`. The
+  plugin now relies on Jekyll 4.3+ collection-read semantics and on
+  the 4.4 `Document#read` shape.
+
+### Behaviour
+
+* **Shrink-only rendering:** the default geometry (`1920x1080`) and
+  any user-supplied `max_size` without an explicit geometry flag now
+  append `>`, so sources smaller than the bounding box are passed
+  through at their original dimensions instead of being upscaled. The
+  geometry is part of both the Geometry- and Render-cache keys, so
+  upgrading invalidates stale upscaled outputs automatically — no
+  `jekyll clean` required.
+* **EXIF Orientation** is now honoured. Sources that previously
+  rendered sideways (Orientation 5–8) will now render upright. Output
+  JPEGs no longer carry the orientation tag.
+* **Encoder defaults:** every rendered JPEG (full-size + thumbs) now
   ships as a progressive JPEG with optimised Huffman tables, explicit
   4:2:0 chroma subsampling, and all metadata stripped (`keep: :none`).
-  Thumbnails are encoded at Q80 and full-size renders honour the
+  Thumbnails are encoded at Q80; full-size renders honour the
   collection-metadata `quality` value (default 85). Previously
   thumbnails used RMagick's default encoder (baseline JPEG, ~Q75, EXIF
   retained). The explicit `subsample_mode: :on` guards against a
-  silent ~25% file-size jump if a user bumps `quality` to ≥ 90 (where
+  silent ~25% file-size jump if `quality` is bumped to ≥ 90 (where
   libvips' `:auto` mode would otherwise switch to 4:4:4).
+* **`max_size` narrowing:** values with ImageMagick trailing flags
+  other than `>` (i.e. `!`, `^`, `@`, `#`) are silently treated as
+  the plain `WxH` form. cheesy-gallery's own config never used these
+  flags; if you depended on them, file an issue.
+* **Generator metadata:** the generator now declares `safe true` (so
+  it whitelists under `jekyll build --safe`) and `priority :low` (so
+  it runs after default-priority generators).
+
+### Bug fixes
+
+* **Render-cache staleness:** the Render-cache key now includes
+  source `mtime`, so in-place edits or re-pointed `git-annex`
+  symlinks no longer silently keep stale renders on subsequent
+  builds.
+* **Jekyll 4.3+ compat:** `Collection#read` snapshots
+  `collection.files` into `site.static_files`, so the generator now
+  re-syncs `site.static_files` after mutating `collection.files`.
+  Without this, generator-added files (thumbs / index renders)
+  silently never reached the writer.
+* **Jekyll 4.4.1 compat:** the synthetic `GalleryIndex` document now
+  overrides `Document#read` directly (rather than the private
+  `read_content`), avoiding an `ENOENT` crash from `read_post_data`
+  on the non-existent backing file.
 * **Robustness:** image header reads now use `fail_on: :error`, so a
   truncated or corrupt source JPEG aborts the build with a clear
   error rather than silently rendering a half-grey output.
-* **Behaviour narrowing:** `max_size` values with ImageMagick trailing
-  flags other than `>` (i.e. `!`, `^`, `@`, `#`) are silently treated
-  as the plain `WxH` form. cheesy-gallery's own config never used
-  these flags; if you depended on them, file an issue.
+
+## Internal changes
+
+* CI matrix expanded to Ruby 3.2 / 3.3 / 3.4 / 4.0; `actions/checkout`
+  bumped to v4; superseded workflow runs auto-cancel per branch;
+  tests run on push only.
+* `BaseImageFile` render path refactored: rendering now happens inside
+  a `copy_file` override; the `write` override is now just the
+  cross-process Render-cache short-circuit. The bespoke `mkdir_p` +
+  `rm` dance was dropped in favour of `super`.
+* Dev dependencies: `codecov` dropped (CI never uploaded coverage);
+  `bundler` dev dep loosened to `>= 2.1`. Fixture lockfile refreshed
+  (rake 13.4.2, tzinfo-data 1.2026.2, plus jekyll, jekyll-feed,
+  jekyll-seo-tag, minima, kramdown, rouge, listen, sass-embedded, et
+  al. to current within constraints).
+* New spec suites: `spec/cheesy/generator_spec.rb` (end-to-end gallery
+  generation, parent/child wiring, thumbnail selection, dimension
+  extraction, `max_size` / `quality` overrides) and
+  `spec/cheesy/cache_spec.rb` (eight cache-layer scenarios derived
+  from `docs/cache-analysis.md`).
+* New internal docs under `docs/`: `repo-research-report.md`,
+  `jekyll-api-review.md`, `cache-analysis.md`, `libvips-bench.md`,
+  `index.md`, `todos.md`. Bench script at `script/bench.rb`.
 
 # 1.1.1
 

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -64,9 +64,10 @@ Newer items at the bottom; tick items off in PRs as they land.
       `3.2`, `3.3`, `3.4`, `4.0`. _Also bumped `actions/checkout` to v4._
 - [x] Update Rubocop's `TargetRubyVersion` in `.rubocop.yml` to match
       the new floor.
-- [ ] Re-run `rake` and the fixture `jekyll build` on each version;
+- [x] Re-run `rake` and the fixture `jekyll build` on each version;
       address any new cop offences or deprecation warnings. _Local run
-      under Ruby 3.3 is clean; awaiting CI matrix run for the rest._
+      under Ruby 3.3 was clean; CI matrix (`3.2`, `3.3`, `3.4`, `4.0`)
+      is now green on the upgraded workflow._
 
 ## 3. Upgrade other dependencies
 
@@ -152,8 +153,10 @@ existing `spec/fixtures/test_site` (or a smaller in-spec fixture):
       `ImageFile` instances carry the expected `@max_size` / `@quality`
       values straight from `collection.metadata` (gallery_one quality
       70 from explicit config; gallery_two defaults to 85)._
-- [ ] Wire spec coverage reporting (simplecov) into `rake` if we keep
-      coverage as a goal.
+- [~] Wire spec coverage reporting (simplecov) into `rake` if we keep
+      coverage as a goal. _Won't do for now: coverage isn't a tracked
+      goal for this gem (CI never uploaded it, and `codecov` was
+      already dropped in §3). Revisit if/when we want a coverage gate._
 
 ## 5. Review Jekyll plugin API surface
 


### PR DESCRIPTION
Wraps up the open items in `docs/todos.md` and brings the 1.2.0 changelog up to date so the branch can land before tagging the release.

## Changes

### `docs/todos.md`

- §2 Ruby upgrade: CI matrix (3.2, 3.3, 3.4, 4.0) is now green on the upgraded workflow; ticked the box.
- §4 spec suite: simplecov marked `[~]` "won't do for now". Coverage isn't a tracked goal — CI never uploaded it and `codecov` was already removed in §3. Easy to revisit if we want a coverage gate later.

### `CHANGELOG.md`

Restructured the 1.2.0 entry into **User-visible** and **Internal** sections and filled in everything that had landed since 1.1.1 but wasn't recorded:

- **User-visible / Breaking** — libvips swap (already there), plus the Ruby `>= 3.2` floor and the Jekyll `~> 4.4` constraint.
- **User-visible / Behaviour** — shrink-only rendering (`>` modifier appended to default + user `max_size`), EXIF orientation, encoder defaults, `max_size` flag narrowing, generator `safe true` + `priority :low`.
- **User-visible / Bug fixes** — Render-cache `mtime` fix (silently stale renders on in-place edits / re-pointed `git-annex` symlinks), Jekyll 4.3+ `site.static_files` re-sync, Jekyll 4.4.1 `Document#read` override for the synthetic `GalleryIndex`, `fail_on: :error` on header reads.
- **Internal** — CI matrix expansion, `copy_file` refactor in `BaseImageFile`, dev-dep churn (codecov dropped, bundler loosened, fixture lockfile refreshed), new `generator_spec.rb` / `cache_spec.rb` suites, new `docs/` reports + bench script.

## Test plan

- [x] `rake` — RuboCop clean (16 files, 0 offences); RSpec 45 examples, 0 failures.
- [x] Fixture `jekyll build` — completes; expected `*_thumb.jpg` and `*_index.jpg` outputs present across `gallery_one`, `gallery_two`, `gallery_two/third`.
- [x] CI matrix (3.2 / 3.3 / 3.4 / 4.0) green prior to this PR — no source changes here.

Release itself is not part of this PR — once merged, the remaining steps are tag `v1.2.0` and manual `gem push` (publish workflow is still disabled pending RubyGems OIDC trusted-publishing setup).

https://claude.ai/code/session_01LDYnYQf4SDCQAcpZDKRspQ